### PR TITLE
Add GA4 metrics to WebPage class

### DIFF
--- a/seovoc.owl
+++ b/seovoc.owl
@@ -212,6 +212,17 @@
 
 
 
+    <!-- https://w3id.org/seovoc/conversions -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/conversions">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:comment>Number of goal or conversion events (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
     <!-- https://w3id.org/seovoc/clicks28Days -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/clicks28Days">
@@ -391,6 +402,39 @@
         <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment>The name of the NLP embedding model used to create vectorized version of the content.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/engagedSessions -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/engagedSessions">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:comment>Sessions with meaningful interaction (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/engagementRate -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/engagementRate">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+        <rdfs:comment>Percentage of engaged sessions (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/averageEngagementTime -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/averageEngagementTime">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#double"/>
+        <rdfs:comment>Average time users actively engaged (GA4).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
     </owl:DatatypeProperty>
 
@@ -779,6 +823,50 @@
         <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:comment>The actual title of the webpage itself</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/trafficSource -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/trafficSource">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Channel or referral source of the visit (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/users -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/users">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:comment>Total users visiting the page (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/sessions -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/sessions">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#long"/>
+        <rdfs:comment>Number of sessions on the page (GA4).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
+    </owl:DatatypeProperty>
+
+
+
+    <!-- https://w3id.org/seovoc/landingPage -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/seovoc/landingPage">
+        <rdfs:domain rdf:resource="https://w3id.org/seovoc/WebPage"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:comment>Page where the session started (GA4).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/seovoc/"/>
     </owl:DatatypeProperty>
 

--- a/seovoc.owx
+++ b/seovoc.owx
@@ -136,7 +136,10 @@
         <DataProperty IRI="ctr7DaysTo3MonthsTrend"/>
     </Declaration>
     <Declaration>
-        <DataProperty IRI="dateCreated"/>
+        <DataProperty IRI="clicks"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="conversions"/>
     </Declaration>
     <Declaration>
         <DataProperty IRI="embedding"/>
@@ -148,7 +151,16 @@
         <DataProperty IRI="embeddingText"/>
     </Declaration>
     <Declaration>
-        <DataProperty IRI="importHash"/>
+        <DataProperty IRI="embeddingText"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="engagedSessions"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="engagementRate"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="averageEngagementTime"/>
     </Declaration>
     <Declaration>
         <DataProperty IRI="importID"/>
@@ -247,7 +259,19 @@
         <DataProperty IRI="value"/>
     </Declaration>
     <Declaration>
-        <NamedIndividual IRI=""/>
+        <DataProperty IRI="title"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="trafficSource"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="users"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="sessions"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty IRI="landingPage"/>
     </Declaration>
     <Declaration>
         <AnnotationProperty abbreviatedIRI="dc:contributors"/>
@@ -347,8 +371,12 @@
         <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyDomain>
-        <DataProperty IRI="clicks28Days"/>
-        <Class IRI="Query"/>
+        <DataProperty IRI="clicks"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="conversions"/>
+        <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyDomain>
         <DataProperty IRI="clicks28DaysTo3MonthsTrend"/>
@@ -415,8 +443,20 @@
         <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyDomain>
-        <DataProperty IRI="importHash"/>
-        <Class abbreviatedIRI="owl:Thing"/>
+        <DataProperty IRI="embeddingText"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="engagedSessions"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="engagementRate"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="averageEngagementTime"/>
+        <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyDomain>
         <DataProperty IRI="importID"/>
@@ -543,8 +583,24 @@
         <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyDomain>
-        <DataProperty IRI="value"/>
-        <Class IRI="URL"/>
+        <DataProperty IRI="title"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="trafficSource"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="users"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="sessions"/>
+        <Class IRI="WebPage"/>
+    </DataPropertyDomain>
+    <DataPropertyDomain>
+        <DataProperty IRI="landingPage"/>
+        <Class IRI="WebPage"/>
     </DataPropertyDomain>
     <DataPropertyRange>
         <DataProperty IRI="anchorValue"/>
@@ -563,7 +619,11 @@
         <Datatype abbreviatedIRI="xsd:long"/>
     </DataPropertyRange>
     <DataPropertyRange>
-        <DataProperty IRI="clicks28Days"/>
+        <DataProperty IRI="clicks"/>
+        <Datatype abbreviatedIRI="xsd:long"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="conversions"/>
         <Datatype abbreviatedIRI="xsd:long"/>
     </DataPropertyRange>
     <DataPropertyRange>
@@ -631,8 +691,20 @@
         <Datatype abbreviatedIRI="xsd:string"/>
     </DataPropertyRange>
     <DataPropertyRange>
-        <DataProperty IRI="importHash"/>
+        <DataProperty IRI="embeddingText"/>
         <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="engagedSessions"/>
+        <Datatype abbreviatedIRI="xsd:long"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="engagementRate"/>
+        <Datatype abbreviatedIRI="xsd:decimal"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="averageEngagementTime"/>
+        <Datatype abbreviatedIRI="xsd:double"/>
     </DataPropertyRange>
     <DataPropertyRange>
         <DataProperty IRI="importID"/>
@@ -765,11 +837,26 @@
         <DataProperty IRI="value"/>
         <Datatype abbreviatedIRI="xsd:string"/>
     </DataPropertyRange>
-    <AnnotationAssertion>
-        <AnnotationProperty abbreviatedIRI="dc:contributors"/>
-        <AbbreviatedIRI>schema:Thing</AbbreviatedIRI>
-        <Literal>Andrea Volpini, David Riccitelli, Emilija Gjorgjevska, Milos Jovanovik</Literal>
-    </AnnotationAssertion>
+    <DataPropertyRange>
+        <DataProperty IRI="value"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="trafficSource"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="users"/>
+        <Datatype abbreviatedIRI="xsd:long"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="sessions"/>
+        <Datatype abbreviatedIRI="xsd:long"/>
+    </DataPropertyRange>
+    <DataPropertyRange>
+        <DataProperty IRI="landingPage"/>
+        <Datatype abbreviatedIRI="xsd:string"/>
+    </DataPropertyRange>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
         <AbbreviatedIRI>schema:Thing</AbbreviatedIRI>

--- a/seovoc.ttl
+++ b/seovoc.ttl
@@ -143,6 +143,14 @@ skos:exactMatch rdf:type owl:AnnotationProperty .
         rdfs:isDefinedBy <https://w3id.org/seovoc/> .
 
 
+###  https://w3id.org/seovoc/conversions
+:conversions rdf:type owl:DatatypeProperty ;
+             rdfs:domain :WebPage ;
+             rdfs:range xsd:long ;
+             rdfs:comment "Number of goal or conversion events (GA4)." ;
+             rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
 ###  https://w3id.org/seovoc/clicks28Days
 :clicks28Days rdf:type owl:DatatypeProperty ;
               rdfs:domain :Query ;
@@ -277,6 +285,30 @@ skos:exactMatch rdf:type owl:AnnotationProperty .
                 rdfs:range xsd:string ;
                 rdfs:comment "The name of the NLP embedding model used to create vectorized version of the content." ;
                 rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/engagedSessions
+:engagedSessions rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :WebPage ;
+                 rdfs:range xsd:long ;
+                 rdfs:comment "Sessions with meaningful interaction (GA4)." ;
+                 rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/engagementRate
+:engagementRate rdf:type owl:DatatypeProperty ;
+                rdfs:domain :WebPage ;
+                rdfs:range xsd:decimal ;
+                rdfs:comment "Percentage of engaged sessions (GA4)." ;
+                rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/averageEngagementTime
+:averageEngagementTime rdf:type owl:DatatypeProperty ;
+                       rdfs:domain :WebPage ;
+                       rdfs:range xsd:double ;
+                       rdfs:comment "Average time users actively engaged (GA4)." ;
+                       rdfs:isDefinedBy <https://w3id.org/seovoc/> .
 
 
 ###  https://w3id.org/seovoc/embeddingText
@@ -558,6 +590,38 @@ skos:exactMatch rdf:type owl:AnnotationProperty .
        rdfs:range xsd:string ;
        rdfs:comment "The actual title of the webpage itself" ;
        rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/trafficSource
+:trafficSource rdf:type owl:DatatypeProperty ;
+               rdfs:domain :WebPage ;
+               rdfs:range xsd:string ;
+               rdfs:comment "Channel or referral source of the visit (GA4)." ;
+               rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/users
+:users rdf:type owl:DatatypeProperty ;
+       rdfs:domain :WebPage ;
+       rdfs:range xsd:long ;
+       rdfs:comment "Total users visiting the page (GA4)." ;
+       rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/sessions
+:sessions rdf:type owl:DatatypeProperty ;
+          rdfs:domain :WebPage ;
+          rdfs:range xsd:long ;
+          rdfs:comment "Number of sessions on the page (GA4)." ;
+          rdfs:isDefinedBy <https://w3id.org/seovoc/> .
+
+
+###  https://w3id.org/seovoc/landingPage
+:landingPage rdf:type owl:DatatypeProperty ;
+             rdfs:domain :WebPage ;
+             rdfs:range xsd:string ;
+             rdfs:comment "Page where the session started (GA4)." ;
+             rdfs:isDefinedBy <https://w3id.org/seovoc/> .
 
 
 ###  https://w3id.org/seovoc/value


### PR DESCRIPTION
This PR adds GA4 metrics to the `seovoc:WebPage` class as proposed in #52.

Files modified:
- `seovoc.ttl`
- `seovoc.owl`
- `seovoc.owx`

Closes #52